### PR TITLE
README は日本語で書く #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# styleguide
-TIMEINTERMEDIA's coding style guides
+# TIMEINTERMEDIA's coding style guides
+各プロジェクトで共通して利用する、 Linter/Formatter の設定をまとめていくリポジトリです。
 
-## Available styles
-- Ruby (Rails)
+## 対応言語（フレームワーク）と Linter/Formatter の一覧
+- [Ruby (Rails)](ruby-rails/README.md) - RuboCop

--- a/ruby-rails/.rubocop.yml
+++ b/ruby-rails/.rubocop.yml
@@ -13,8 +13,8 @@ AllCops:
     - vendor/**/*
 
 ########################################
-# Bundler Cops: Cops for Gemfile
-#   - Follow RuboCop's default style
+# Bundler Cops: Gemfile 用の設定
+#   - RuboCop のデフォルト設定に従う
 ########################################
 
 

--- a/ruby-rails/README.md
+++ b/ruby-rails/README.md
@@ -1,15 +1,15 @@
-# Style for Ruby on Rails
+# Ruby on Rails 用 Linter/Formatter 設定
 
 ## Linter/Formatter
 - RuboCop
 
-### Using extensions
+### Extensions
 - RuboCop Performance
 - RuboCop Rails
 - RuboCop RSpec
 
-## How to use
-### 1. Create following files in project root
+## 使い方
+### 1. 必要なファイルを、プロジェクトのルートディレクトリに作成する
 - Gemfile
   ```ruby
   # frozen_string_literal: true
@@ -35,10 +35,10 @@
   AllCops:
     TargetRubyVersion: 2.7
 
-  # Customize cops for each project here.
+  # 必要な場合は、ここにプロジェクトごとのカスタム設定を書く
   ```
 
-### 2. Run RuboCop
+### 2. RuboCop の実行
 ```sh
 bundle install
 bundle exec rubocop


### PR DESCRIPTION
## Issues
Close: #3  

## やったこと
README の修正
- 日本語を使う
- 対応言語一覧のリンク化
- ruby-rails/.rubocop.yml のコメントも日本語で書いていく