### PR TITLE
非推奨のパラメータ ExcludeMethods を IgnoreMethods にリネーム

### DIFF
--- a/ruby/rubocop/base.yml
+++ b/ruby/rubocop/base.yml
@@ -231,7 +231,7 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   Enabled: true
   CountComments: false
-  ExcludedMethods:
+  IgnoredMethods:
     - class_methods
     - concern
     - describe


### PR DESCRIPTION
### 関連する Issues

実行時に以下の warning が表示されます。

```
Warning: obsolete parameter `ExcludedMethods` (for `Metrics/BlockLength`) found in .rubocop-https---raw-githubusercontent-com-timedia-styleguide-master-ruby-rubocop-base-yml
`ExcludedMethods` has been renamed to `IgnoredMethods`.
```

### やったこと

新パラメータ名に変更しました。