### PR TITLE
labeler workflow: trigger を変更

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,7 +1,7 @@
 name: Add label to each pull request
 
 on:
-  - pull_request
+  - pull_request_target
 
 jobs:
   triage:


### PR DESCRIPTION
- fork 先リポジトリから fork 元リポジトリへの PR 時に、Pull Request にラベルを付与する権限が足りない
- `on: pull_request` から `on: pull_request_target` に変更することで、fork 元リポジトリの GITHUB_TOKEN が使えるようになる

CAUTION: `on: pull_request_target` トリガを利用する場合、トリガ条件を絞る、`permissions` キーが指定するなど、権限の管理には注意すること
https://docs.github.com/ja/actions/using-workflows/events-that-trigger-workflows#pull_request_target
