### PR TITLE
Use GitHub-native Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,10 @@ updates:
       time: "10:00"
       timezone: "Asia/Tokyo"
 
-  - package-ecosystem: "bundler"
-    directory: "/ruby"
-    schedule:
-      interval: "daily"
-      time: "10:00"
-      timezone: "Asia/Tokyo"
-    versioning-strategy: "increase"
+  # - package-ecosystem: "bundler"
+  #   directory: "/ruby"
+  #   schedule:
+  #     interval: "daily"
+  #     time: "10:00"
+  #     timezone: "Asia/Tokyo"
+  #   versioning-strategy: "increase"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "10:00"
+      timezone: "Asia/Tokyo"
+
+  - package-ecosystem: "bundler"
+    directory: "/ruby"
+    schedule:
+      interval: "daily"
+      time: "10:00"
+      timezone: "Asia/Tokyo"
+    versioning-strategy: "increase"


### PR DESCRIPTION
### 関連する Issues
Close #78 

### やったこと
- GitHub 組み込みの Dependabot を使う
- github-actions の更新も監視させる