### PR TITLE
Metrics/PerceivedComplexity: 最新のデフォルト値に追従

### DIFF
--- a/ruby/rubocop/config/base.yml
+++ b/ruby/rubocop/config/base.yml
@@ -304,14 +304,14 @@ Metrics/ParameterLists:
   CountKeywordArgs: true
   Max: 4
 
-# 見た目の複雑さ？スコアの最大は7とする
+# 見た目の複雑さ？スコアの最大は8とする
 #   - RuboCop のデフォルトに従う
 #
 #   RuboCop Docs: https://docs.rubocop.org/rubocop/cops_metrics.html#metricsperceivedcomplexity
 #
 Metrics/PerceivedComplexity:
   Enabled: true
-  Max: 7
+  Max: 8
 
 
 ########################################


### PR DESCRIPTION
https://docs.rubocop.org/rubocop/cops_metrics.html#metricsperceivedcomplexity
を確認したところ、現在は 8 がデフォルトになっているようです。
