### PR TITLE
RSpec/MultipleExpectations: ひとつの example に 10件まで expect を書けるようにする

### DIFF
--- a/ruby/rubocop/config/rspec.yml
+++ b/ruby/rubocop/config/rspec.yml
@@ -22,3 +22,11 @@ RSpec/ContextWording:
 #
 RSpec/NamedSubject:
   Enabled: false
+
+# ひとつの example に配置できる expectation の数に上限を設ける
+#   - 10件まで expectation を書けるようにする
+#
+#   RuboCop Docs: https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecmultipleexpectations
+#
+RSpec/MultipleExpectations:
+  Max: 10


### PR DESCRIPTION
さまざまなデータを扱う Web ページでは複数の変更が行われるため、複数の
expect を並べることはよく行われていることです。

標準では 1件までしか expect を書くべきではないとする
RSpec/MultipleExpectations を 10件まで許容するように変更します。
(10件という値に特別な意味はありません。5件では少ないだろうという直感によ
るものです)


