### PR TITLE
RuboCop の要求バージョンを 1.30.0 以上に上げる

### DIFF
--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -20,7 +20,7 @@ gemspec path: './rubocop'
 #       + gem 'rubocop', '~> 1.30.0'
 #       ```
 #
-gem 'rubocop', '~> 1.27.0'
+gem 'rubocop', '~> 1.30.0'
 gem 'rubocop-performance', '~> 1.13.0'
 gem 'rubocop-rails', '~> 2.14.0'
 gem 'rubocop-rspec', '~> 2.10.0'

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -64,3 +64,8 @@
 bundle install
 bundle exec rubocop
 ```
+
+## Tips
+### 未定義の Cop が読み込めず、RuboCop の実行に失敗してしまう
+1. `bundle update rubocop` して、RuboCop のバージョンを上げてください
+2. （解決しない/できない場合）RuboCop の実行時に `--ignore-unrecognized-cops` オプションを指定してください

--- a/ruby/rubocop/rubocop-config-timedia.gemspec
+++ b/ruby/rubocop/rubocop-config-timedia.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['config/*.yml']
 
-  spec.add_runtime_dependency 'rubocop', '>= 1.27.0'
+  spec.add_runtime_dependency 'rubocop', '>= 1.30.0'
   spec.add_runtime_dependency 'rubocop-performance', '>= 1.13.0'
   spec.add_runtime_dependency 'rubocop-rails', '>= 2.14.0'
   spec.add_runtime_dependency 'rubocop-rspec', '>= 2.10.0'


### PR DESCRIPTION
after #102 

### やったこと
RuboCop の要求バージョンを 1.30.0 以上に上げる
- `--ignore-unrecognized-cops` オプションが使えるようにしたい
  - https://github.com/rubocop/rubocop/releases/tag/v1.30.0