### PR TITLE
RuboCop の要求バージョンを 1.33.0 以上に上げる

### DIFF
--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -20,7 +20,7 @@ gemspec path: './rubocop'
 #       + gem 'rubocop', '~> 1.30.0'
 #       ```
 #
-gem 'rubocop', '~> 1.30.0'
+gem 'rubocop', '~> 1.33.0'
 gem 'rubocop-performance', '~> 1.13.0'
 gem 'rubocop-rails', '~> 2.14.0'
 gem 'rubocop-rspec', '~> 2.10.0'

--- a/ruby/rubocop/config/base.yml
+++ b/ruby/rubocop/config/base.yml
@@ -232,14 +232,11 @@ Metrics/BlockLength:
   Enabled: true
   CountComments: false
   AllowedMethods:
-    - Enabled
-    - CountComments
-    - Max
-    - CountAsOne
-    - AllowedMethods
-    - AllowedPatterns
-    - Exclude
-    - inherit_mode
+    - class_methods
+    - concern
+    - describe
+    - included
+    - refine
   Max: 25
 
 # Block のネストは最大3段までとする

--- a/ruby/rubocop/config/base.yml
+++ b/ruby/rubocop/config/base.yml
@@ -231,12 +231,15 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   Enabled: true
   CountComments: false
-  IgnoredMethods:
-    - class_methods
-    - concern
-    - describe
-    - included
-    - refine
+  AllowedMethods:
+    - Enabled
+    - CountComments
+    - Max
+    - CountAsOne
+    - AllowedMethods
+    - AllowedPatterns
+    - Exclude
+    - inherit_mode
   Max: 25
 
 # Block のネストは最大3段までとする

--- a/ruby/rubocop/rubocop-config-timedia.gemspec
+++ b/ruby/rubocop/rubocop-config-timedia.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['config/*.yml']
 
-  spec.add_runtime_dependency 'rubocop', '>= 1.30.0'
+  spec.add_runtime_dependency 'rubocop', '>= 1.33.0'
   spec.add_runtime_dependency 'rubocop-performance', '>= 1.13.0'
   spec.add_runtime_dependency 'rubocop-rails', '>= 2.14.0'
   spec.add_runtime_dependency 'rubocop-rspec', '>= 2.10.0'


### PR DESCRIPTION
## やったこと
RuboCop の要求バージョンを 1.33.0 以上に上げる

`IgnoreMethods`は1.33.0以降から`AllowedMethods`に変更されたため、以下の２点の変更を行った
- base.ymlのMetrics/BlockLengthの変更
- rubocopのバージョンを1.30.0から1.33.0に変更
 [rubocop-config-timedia.gemspec](https://github.com/Taku3939/styleguide/blob/tisaki/update-block-length/ruby/rubocop/rubocop-config-timedia.gemspec)の`spec.add_runtime_dependency 'rubocop', '>= 1.33.0'`と[Gemfile](https://github.com/Taku3939/styleguide/blob/tisaki/update-block-length/ruby/Gemfile)の
`gem 'rubocop', '~> 1.33.0'`の2箇所を変更した
