### PR TITLE
ruby: rubocop-factory_bot gem に対応

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -3,6 +3,7 @@
 inherit_gem:
   rubocop-config-timedia:
     - config/base.yml
+    - config/factory_bot.yml
     - config/rails.yml
     - config/rspec.yml
 

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -20,7 +20,8 @@ gemspec path: './rubocop'
 #       + gem 'rubocop', '~> 1.30.0'
 #       ```
 #
-gem 'rubocop', '~> 1.33.0'
+gem 'rubocop', '~> 1.47.0'
+gem 'rubocop-factory_bot', '~> 2.22.0'
 gem 'rubocop-performance', '~> 1.13.0'
 gem 'rubocop-rails', '~> 2.14.0'
-gem 'rubocop-rspec', '~> 2.10.0'
+gem 'rubocop-rspec', '~> 2.22.0'

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -20,7 +20,7 @@ gemspec path: './rubocop'
 #       + gem 'rubocop', '~> 1.30.0'
 #       ```
 #
-gem 'rubocop', '~> 1.47.0'
+gem 'rubocop', '~> 1.41.0'
 gem 'rubocop-factory_bot', '~> 2.22.0'
 gem 'rubocop-performance', '~> 1.13.0'
 gem 'rubocop-rails', '~> 2.14.0'

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -31,6 +31,7 @@
         - config/base.yml
         - config/rails.yml
         - config/rspec.yml # RSpec 利用時のみ
+        - config/factory_bot.yml # FactoryBot 利用時のみ
 
     AllCops:
       TargetRubyVersion: 2.7
@@ -50,6 +51,7 @@
       rubocop-config-timedia:
         - config/base.yml
         - config/rspec.yml # RSpec 利用時のみ
+        - config/factory_bot.yml # FactoryBot 利用時のみ
 
     AllCops:
       TargetRubyVersion: 2.7

--- a/ruby/rubocop/config/factory_bot.yml
+++ b/ruby/rubocop/config/factory_bot.yml
@@ -1,0 +1,8 @@
+# RuboCop FactoryBot の設定ファイル
+# 通常、基本設定ファイル (base.yml) と同時に利用する
+
+require: rubocop-factory_bot
+
+########################################
+# FactoryBot Cops: TODO
+########################################

--- a/ruby/rubocop/rubocop-config-timedia.gemspec
+++ b/ruby/rubocop/rubocop-config-timedia.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['config/*.yml']
 
-  spec.add_runtime_dependency 'rubocop', '>= 1.33.0'
+  spec.add_runtime_dependency 'rubocop', '>= 1.41.0'
   spec.add_runtime_dependency 'rubocop-factory_bot', '>= 2.22.0'
   spec.add_runtime_dependency 'rubocop-performance', '>= 1.13.0'
   spec.add_runtime_dependency 'rubocop-rails', '>= 2.14.0'

--- a/ruby/rubocop/rubocop-config-timedia.gemspec
+++ b/ruby/rubocop/rubocop-config-timedia.gemspec
@@ -14,7 +14,8 @@ Gem::Specification.new do |spec|
   spec.files = Dir['config/*.yml']
 
   spec.add_runtime_dependency 'rubocop', '>= 1.33.0'
+  spec.add_runtime_dependency 'rubocop-factory_bot', '>= 2.22.0'
   spec.add_runtime_dependency 'rubocop-performance', '>= 1.13.0'
   spec.add_runtime_dependency 'rubocop-rails', '>= 2.14.0'
-  spec.add_runtime_dependency 'rubocop-rspec', '>= 2.10.0'
+  spec.add_runtime_dependency 'rubocop-rspec', '>= 2.22.0'
 end


### PR DESCRIPTION
rubocop-rspec-2.22.0 から factory_bot 関連の機能が別の gem
(rubocop-factory_bot gem) に切り出されることになったため、
依存関係に rubocop-factory_bot gem を追加した。

また、今後設定を増やすことを想定し、factory_bot 用の空の YAML ファイルを
用意した。

https://github.com/rubocop/rubocop-rspec/blob/master/CHANGELOG.md#2220-2023-05-06


