### PR TITLE
Update TargetRubyVersion to 3.2 (oldest maintained version)

### DIFF
--- a/.github/workflows/ruby.yaml
+++ b/.github/workflows/ruby.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.2'
           bundler-cache: true
           working-directory: ./ruby
 

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -8,4 +8,4 @@ inherit_gem:
     - config/rspec.yml
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.2

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -9,3 +9,7 @@ inherit_gem:
 
 AllCops:
   TargetRubyVersion: 3.2
+
+Gemspec/RequiredRubyVersion:
+  Exclude:
+    - rubocop/rubocop-config-timedia.gemspec

--- a/ruby/rubocop/rubocop-config-timedia.gemspec
+++ b/ruby/rubocop/rubocop-config-timedia.gemspec
@@ -4,7 +4,9 @@ Gem::Specification.new do |spec|
   spec.name    = 'rubocop-config-timedia'
   spec.version = '0.1.0'
   spec.summary = 'The default RuboCop configuration for TIMEINTERMEDIA, Inc.'
-  spec.required_ruby_version = '>= 2.7.0'
+  # NOTE: このgemにはRubyコードを含まないため、要求するRubyバージョンはRuboCop gemと同じ
+  #   -> 明示的に指定するとRuboCopの変更を追従しなければならないため、コメントアウトする
+  # spec.required_ruby_version = '>= 2.7.0'
 
   spec.authors  = ['Ryo MAEDA']
   spec.metadata = {


### PR DESCRIPTION
### 関連する Issues

### やったこと
`.github/workflows`, `ruby/.rubocop.yml` の対象Rubyバージョンを3.2に変更する
- 3.2 = PR時点でEOLを迎えていない最も古いバージョン
  - https://www.ruby-lang.org/en/downloads/branches/
